### PR TITLE
Only build travis push on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ sudo: false
 language: python
 python:
   - "3.4"
+branches:
+  only:
+    - master
 install: pip install -r requirements/travis.txt
 script: make test-all


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
- [ ] Test changes published to Read the Docs appear as expected

I've been working on adding some automation for creating and testing openedx releases, which creates branches in a number of IDA's, and (if desired) deletes them at the end of the tests. For now, the job is in the beginning stages, and just creates a branch, and later deletes it.

The problem is, the branch gets deleted so quickly, that travis gets kicked off, but quickly fails when the branch can't be found. To make matters worse, since the branch doesn't include any new commits, travis gets run (and fails) on the same commit as the tip of the master branch, which overwrites whatever status it previously had to failing (example: link to failing travis build).

This change fixes that, by following a travis pattern we currently already use in other repos, like these: (configuration repo, devstack repo). This will limit builds to being triggered either by a pull request, or a push to master.

So when any non-master branch gets created or pushed, travis will not be triggered (unless there is an open pull request for that branch).