### PR TITLE
[BD-34] Move legacy docs Section 1 info into proper slots in new repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,12 +56,12 @@ otherwise noted.
 
 Please see ``LICENSE.txt`` for details.
 
-How To Contribute
------------------
+How To Contribute To This Repository
+-------------------------------------
 
 Contributions are very welcome.
 
-Please read `How To Contribute <https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
+Please read :ref:`Contributing to Open edX developer documentation` for details.
 
 Even though they were written with ``edx-platform`` in mind, the guidelines
 should be followed for Open edX code in general.

--- a/docs/all_development/contributing/dev_docs.rst
+++ b/docs/all_development/contributing/dev_docs.rst
@@ -1,0 +1,20 @@
+.. Some information copied from edx-documentation/en-us/developers/read_me.rst
+
+.. _Contributing to Open edX developer documentation:
+
+#################################################
+Contributing to Open edX developer documentation
+#################################################
+
+The **edX Developer Documentation** is based on `RST`_ source files, and `Sphinx`_ uses the source files to create the finished docs.
+
+You, as part of the user community, can help update and revise this documentation project
+on GitHub.
+
+https://github.com/edx/edx-developer-docs
+
+**Before you begin writing your contribution**, make sure you are familiar with the practices laid out in the accepted `Open edX technical proposal regarding developer documentation <https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html>`_. 
+
+
+.. _RST: http://docutils.sourceforge.net/rst.html
+.. _Sphinx: http://sphinx-doc.org

--- a/docs/all_development/contributing/finding_help.rst
+++ b/docs/all_development/contributing/finding_help.rst
@@ -1,0 +1,84 @@
+.. Information copied from edx-documentation/shared/preface.rst
+
+.. _Finding help for your development work:
+
+#################################################
+Finding help for your development work
+#################################################
+
+*************
+Getting help
+*************
+
+The `Getting Help`_ page in the Open edX Portal lists different
+ways that you can ask, and get answers to, questions.
+
+.. _Getting Help: https://open.edx.org/getting-help
+
+********************
+Wikis and web sites
+********************
+
+The `Open edX Portal`_ is the entry point for new contributors.
+
+The edX Engineering team maintains an `open Confluence wiki`_, which
+provides insights into the plans, projects, and questions that the edX Open
+Source team is working on with the community.
+
+*******************************************
+Resources for the entire Open edX community
+*******************************************
+
+Hosting providers, platform extenders, core contributors, and course staff all
+use Open edX. EdX provides release-specific documentation, as well as the
+latest version of all guides, for Open edX users.
+
+See `Open edX documentation`_ for information in areas other than software development.
+
+
+.. _Building and Running an edX Course: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/
+.. _Building and Running an Open edX Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
+.. _Building and Running an Open edX Course - latest: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
+.. _docs@edx.org: docs@edx.org
+.. _edx101: https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VIIJbWTF_yM
+.. _StudioX: https://www.edx.org/course/creating-course-edx-studio-edx-studiox#.VRLYIJPF8kR
+.. _BlendedX: https://www.edx.org/course/blended-learning-edx-edx-blendedx-1
+.. _VideoX: https://www.edx.org/course/creating-video-edx-platform-edx-videox
+.. _Demo: http://www.edx.org/course/edx/edx-edxdemo101-edx-demo-1038
+.. _edX Partner Support: https://partners.edx.org/edx_zendesk
+.. _edx-code: http://groups.google.com/forum/#!forum/edx-code
+.. _edx/configuration: http://github.com/edx/configuration/wiki
+.. _edX Data Analytics API: http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/index.html
+.. _docs.edx.org: http://docs.edx.org
+.. _edx/edx-analytics-dashboard: https://github.com/edx/edx-analytics-dashboard
+.. _edx/edx-platform: https://github.com/edx/edx-platform
+.. _EdX Learner's Guide: http://edx-guide-for-students.readthedocs.io/en/latest/
+.. _edX Support: https://courses.edx.org/support/contact_us
+.. _edX Help Center for Learners: https://support.edx.org/hc/en-us/
+.. _edX Developer Documentation: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/
+.. _edX Open Learning XML Guide: http://edx-open-learning-xml.readthedocs.io/en/latest/index.html
+.. _edX Partner Portal: https://partners.edx.org
+.. _forums: https://partners.edx.org/forums/partner-forums
+.. _edX Research Guide: http://edx.readthedocs.io/projects/devdata/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/
+.. _edX Status: http://status.edx.org/
+.. _edx-tools: https://github.com/edx/edx-tools/wiki
+.. _frequently asked questions: http://www.edx.org/student-faq
+.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/
+.. _meetup: http://www.meetup.com/edX-Global-Community/
+.. _openedx-analytics: http://groups.google.com/forum/#!forum/openedx-analytics
+.. _Open edX documentation: http://docs.edx.org/openedx.html
+.. _Open edX Analytics: http://edx-wiki.atlassian.net/wiki/display/OA/Open+edX+Analytics+Home
+.. _Open edX Learner's Guide: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/
+.. _openedx-ops: http://groups.google.com/forum/#!forum/openedx-ops
+.. _Open edX Portal: https://open.edx.org
+.. _open.edx.org/user/register: https://open.edx.org/user/register
+.. _Open edX Release Notes: http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/
+.. _openedx-studio: http://groups.google.com/forum/#!forum/openedx-studio
+.. _openedx-translation: http://groups.google.com/forum/#!forum/openedx-translation
+.. _open Confluence wiki: http://openedx.atlassian.net/wiki/
+.. _partners.edx.org: https://partners.edx.org
+.. _Twitter:  http://twitter.com/edXstatus
+.. _Using edX Insights: http://edx-insights.readthedocs.io/en/latest/
+.. _Open EdX XBlock API Guide: http://edx.readthedocs.io/projects/xblock/en/latest/
+.. _Open edX XBlock Tutorial: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/index.html

--- a/docs/all_development/contributing/index.rst
+++ b/docs/all_development/contributing/index.rst
@@ -28,7 +28,8 @@ Before you write code:
 * Collaboration
 * Open Source
 * UX/Design/Front End Development
-* Contributing to the Documentation for Your Open Source Feature
+* :doc:`dev_docs`
+* :doc:`finding_help`
 
 Opening a pull request:
 
@@ -37,6 +38,13 @@ Opening a pull request:
 * Further Information
 * Pull Request Cover Letter
 * Example Of A Good PR Cover Letter
+
+.. toctree::
+   :hidden:
+   :caption: Information for all Open edX developers
+
+   dev_docs
+   finding_help
 
 Community Manager
 =================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,7 +101,7 @@ Review this information at your leisure.
      - Confluence page for notes, thoughts, and project-related documents on Open edX architecture and engineering.
    * - `Open edX glossary <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/glossary.html>`_
      - Glossary of terms unique to the Open edX environment.
-   * - :doc:`Supported browsers <universal_stub>`
+   * - :doc:`technical_reference/browser_support`
      - Supported browsers
    * - :doc:`technical_reference/named_releases`
      - Named releases
@@ -112,7 +112,7 @@ Review this information at your leisure.
 
    Architecture and engineering Confluence information hub <https://openedx.atlassian.net/wiki/spaces/AC/overview>
    Open edX glossary <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/glossary.html>
-   Supported browsers <universal_stub>
+   technical_reference/browser_support
    technical_reference/named_releases
 
 
@@ -120,19 +120,11 @@ Review this information at your leisure.
 Information for other user groups
 =================================
 
-* :doc:`Course authoring teams <universal_stub>`
-* :doc:`System administrators <universal_stub>`
-* :doc:`Researchers <universal_stub>`
-* :doc:`Open edX partners <universal_stub>`
-* :doc:`Learners <universal_stub>`
+If your tasks include system administration, course authoring, or anything outside of software development, review the options on `Documentation for edx.org and the Open edX community <http://docs.edx.org>`_.
 
 
 .. toctree::
    :hidden:
    :caption: Information for other user groups
 
-   Course authoring teams <universal_stub>
-   System administrators <universal_stub>
-   Researchers <universal_stub>
-   Open edX partners <universal_stub>
-   Learners <universal_stub>
+   Documentation for edx.org and the Open edX community <http://docs.edx.org>

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -1,0 +1,15 @@
+.. Browsers
+
+.. _Chrome: https://www.google.com/chrome
+
+.. _Safari: https://www.apple.com/safari
+
+.. _Firefox: https://mozilla.org/firefox
+
+.. _Microsoft Edge: https://www.microsoft.com/microsoft-edge
+
+.. _Microsoft Internet Explorer: http://windows.microsoft.com/internet-explorer/download-ie
+
+.. edX sites
+
+.. _docs.edx.org: http://docs.edx.org

--- a/docs/technical_reference/browser_support.rst
+++ b/docs/technical_reference/browser_support.rst
@@ -1,0 +1,28 @@
+.. Information copied with slight changes from edx-documentation/shared/browsers.rst
+
+.. _Browsers:
+
+####################
+Browser support
+####################
+
+edX application pages render correctly and swiftly in most modern browsers.
+
+**All code must support the latest versions of the browsers mentioned below.**
+
+For best performance, we recommend:
+
+* `Chrome`_
+* `Firefox`_
+
+We also support the latest versions of:
+
+* `Microsoft Edge`_
+* `Microsoft Internet Explorer`_
+* `Safari`_
+
+
+.. note:: If you use the Safari browser, be aware that it does not support the
+ search feature for the guides on `docs.edx.org`_. This is a known limitation.
+
+.. include:: ../links.rst

--- a/docs/technical_reference/named_releases.rst
+++ b/docs/technical_reference/named_releases.rst
@@ -1,5 +1,5 @@
 #######################
-Open edX Named Releases
+Named releases
 #######################
 
 The Open edX community can share knowledge and improvements more easily when most people use the same stable, consistent version of the Open edX codebase. To that end, edX creates "Open edX named releases", which are distinct from the daily deployments to edx.org and have a longer release cycle (on the order of six months between each release). These releases will be tested both by edX and by the Open edX community.


### PR DESCRIPTION
**Description:**  

Certain info in legacy developer docs section 1 (contributing to dev docs, browser support, etc) needs to be reslotted into the new outline. 

Contributing to dev docs and getting help as a developer can be found in the Contributing section.

Browser support is in the technical reference section.

Information for users other than developers is a link at the very end of the root index.rst. 

Reviewers: please disregard the apparently extraneous headings in the Contributing section. These will be removed in a separate PR. 

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
- [ ] Test changes published to Read the Docs appear as expected
