### PR TITLE
[BD-34] Reduce number of bullets on contributing/index.rst to remove refs to obsolete or future content

### DIFF
--- a/docs/all_development/contributing/index.rst
+++ b/docs/all_development/contributing/index.rst
@@ -2,47 +2,10 @@
 Contributing to Open edX code and documentation
 ###############################################
 
-Overview
-========
+.. removed most bullets pending rework of contributor role responsibilities by Ned and Nimisha, review of some content by other developers
 
-General Guidelines
-==================
-
-Contribution Roles and Tasks
-============================
-
-Contributor
-===========
-
-Before you write code:
-
-* Writing Good Code
+* Writing good code
 * Internationalization
 * Accessibility
-* Security Principles
-* Operational Impact
-* Documentation/Training/Support
-* Development
-* Testing
 * Analytics
-* Collaboration
-* Open Source
-* UX/Design/Front End Development
-* Contributing to the Documentation for Your Open Source Feature
-
-Opening a pull request:
-
-
-* Once A PR is Open
-* Further Information
-* Pull Request Cover Letter
-* Example Of A Good PR Cover Letter
-
-Community Manager
-=================
-
-Product Owner
-=============
-
-Core Committer Program
-======================
+* Language style guidelines


### PR DESCRIPTION
**Description:** This PR trims down the list of subject in the index file for "Contributing to Open edX" so that only content that is likely to be added during the next couple of weeks is included. 

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
- [ ] Test changes published to Read the Docs appear as expected
