### PR TITLE
docs: add a link to devstack docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'edx-developer-docs'
+project = 'Open edX Developer Docs'
 copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
 author = edx_theme.AUTHOR
 project_title = 'Open edX Developer Documentation'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,10 @@ Open edX Development
 
 .. list-table::
 
+   * - `Devstack <https://edx.readthedocs.io/projects/open-edx-devstack/en/latest>`_
+     - The local development environment for developing in the Open edX
+       platform.
+
    * - `Open edX Named Releases <named_releases.html>`_
      - Information on each stable Open edX named release.
 


### PR DESCRIPTION
**Description:** The developer documentation should have a link to devstack.  This adds it.

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
- [ ] Test changes published to Read the Docs appear as expected
