### PR TITLE
docs: rename developers_guide to micro_frontends

### DIFF
--- a/docs/developers_guide/index.rst
+++ b/docs/developers_guide/index.rst
@@ -1,9 +1,0 @@
-##########################
-Open edX Developer's Guide
-##########################
-
-This the landing page for developer guides created by the edX Engineering team. It contains guides relevant to developers of the Open edX platform.  This guide is intended to replace the `(Legacy) Open edX Developer's Guide <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/>`_.
-
-.. toctree::
-
-    micro_frontends_in_open_edx

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ resources targeted for edX learners, educators, researchers, and Open edX operat
     :hidden:
 
     Open edX Proposals <https://open-edx-proposals.readthedocs.io/en/latest/>
-    developers_guide/index
+    micro_frontends/index
     named_releases
     Open edX Extensions and APIs <https://open.edx.org/extending-edx>
     (Legacy) Open edX Developer's Guide <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/>
@@ -31,8 +31,8 @@ Architecture and Best Practices
    * - `Architecture and Engineering Confluence page <https://openedx.atlassian.net/wiki/spaces/AC/overview>`_
      - Confluence page for notes, thoughts, and project-related documents on Open edX architecture and engineering.
 
-   * - `(New) Open edX Developer's Guide <developers_guide/index.html>`_
-     - General guidelines for developing on various parts of the Open edX code base.
+   * - `Open edX Micro-frontend Developer's Guide <micro_frontends/index.html>`_
+     - General guidelines for developing micro-frontends in the Open edX platform.
 
    * - `(Legacy) Open edX Developer's Guide <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/>`_
      - General guidelines for developing on various parts of the Open edX code base.

--- a/docs/micro_frontends/index.rst
+++ b/docs/micro_frontends/index.rst
@@ -1,6 +1,6 @@
-#######################################
-Micro-frontend applications in Open edX
-#######################################
+#########################################
+Open edX Micro-frontend Developer's Guide
+#########################################
 
 The purpose of this document is to provide an overview of how micro-frontend applications (MFEs) are developed, configured, and deployed with the Open edX ecosystem. Open edX MFEs are small React applications that can be built and deployed independently.
 


### PR DESCRIPTION
This is part one of a proposed re-organization of this repository.

This renames the "developers_guide" directory to "micro_frontends" and simplifies the content to be specific to MFEs (with no meaningful content lost).  That's all that was in there anyway.

Other topics will get other sibling sub-directories, with the expectation that we may have "Developer's Guide"s for particular topics, but that the whole repository is "Developer Documentation".  Having both "Developer's Guide" and "Developer Documentation" as top-level concepts feels confusing.

Specifically, I'm hoping to move the content in  edx-documentation/en_us/developers into this repository as siblings to the "micro_frontends" content.  TBD the exact organization/information architecture, but this commit feels like a simple, non-controversial start.

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
- [ ] Test changes published to Read the Docs appear as expected
