### PR TITLE
fix: adds learning base url

### DIFF
--- a/docs/micro_frontends/index.rst
+++ b/docs/micro_frontends/index.rst
@@ -95,6 +95,12 @@ Status: DEPRECATED
 
 The fully-qualified URL of the `Ecommerce Service <https://github.com/edx/ecommerce>`_ in the target environment.
 
+``LEARNING_BASE_URL``
+
+Example: ``https://learning.example.com``
+
+The fully-qualified URL of the `Frontend App Learning <https://github.com/edx/frontend-app-learning>`_ in the target environment.
+
 ``LMS_BASE_URL``
 
 Example: ``https://courses.example.com``


### PR DESCRIPTION

**Description:** This PR adds `LEARNING_BASE_URL` in the docs. it is a URL to the "Frontend App Learning" MFE in the target environment.

**JIRA:** https://openedx.atlassian.net/browse/TNL-9227

<img width="604" alt="Screen Shot 2021-11-04 at 10 10 00 AM" src="https://user-images.githubusercontent.com/4252738/140261232-7ee68363-1610-4edf-991c-543cebe9d966.png">




**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Commits are squashed as needed
- [x] Review Read the Docs PR build to ensure changes appear as expected
